### PR TITLE
Specify UTF-8 encoding when reading domain list

### DIFF
--- a/header.py
+++ b/header.py
@@ -133,7 +133,7 @@ def main(start_line=0):
                 thread_safe_print(f"Process for prestart test already terminated.")
 
     # Read domains from the input file
-    with open(list_file, "r", encoding="utf-8", errors="ignore") as domains_file:
+    with open(list_file, "r", encoding="utf-8") as domains_file:
         domains = domains_file.read().splitlines()
 
     # Initialize result file if it does not exist or is empty

--- a/header.py
+++ b/header.py
@@ -38,7 +38,7 @@ makedirs('./configs')
 
 def configer(domain, port_socks, port_http, config_index):
     # Read the base configuration template
-    with open("./main.json", "rt") as main_config_file:
+    with open("./main.json", "r", encoding="utf-8") as main_config_file:
         main_config = loads(main_config_file.read())
     # Update configuration with specific domain and ports
     main_config["outbounds"][0]["streamSettings"]["tcpSettings"]["header"]["request"]["headers"]["Host"] = domain
@@ -133,7 +133,7 @@ def main(start_line=0):
                 thread_safe_print(f"Process for prestart test already terminated.")
 
     # Read domains from the input file
-    with open(list_file, "rt") as domains_file:
+    with open(list_file, "r", encoding="utf-8", errors="ignore") as domains_file:
         domains = domains_file.read().splitlines()
 
     # Initialize result file if it does not exist or is empty


### PR DESCRIPTION
## Summary
- Explicitly open `main.json` and the domain list with UTF-8 encoding to avoid UnicodeDecodeError on Windows.

## Testing
- `python -m py_compile header.py`


------
https://chatgpt.com/codex/tasks/task_b_6892a32b19408333ad06a3c85529f86d